### PR TITLE
Remove hero CTA and add plan CTA

### DIFF
--- a/src/app/_components/cto-partner/index.tsx
+++ b/src/app/_components/cto-partner/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { CtoPartnerCta } from "../cto-partner-cta";
 import { EngineeringElements } from "../engineering-elements";
 import { ServicePlans } from "../service-plans";
 import { CtoPartnerHero } from "./cto-partner-hero";
@@ -14,7 +13,7 @@ export function CtoPartner() {
         <ServicePlans />
         {/* <PhaseSupport />
         <EngagementStyle />*/}
-        <CtoPartnerCta /> 
+        {/* <CtoPartnerCta /> */}
       </main>
     </div>
   );

--- a/src/app/_components/service-plans.tsx
+++ b/src/app/_components/service-plans.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle, ChevronRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { DownloadButton } from "./download-button";
 
 export function ServicePlans() {
   return (
@@ -116,6 +117,14 @@ export function ServicePlans() {
               </Button>
             </div>
           </Card>
+        </div>
+        <div className="flex justify-center mt-16">
+          <div className="text-center">
+            <p className="text-gray-600 mb-6">具体的な費用感を含む資料もどうぞ！</p>
+            <div className="flex justify-center">
+              <DownloadButton />
+            </div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- hide the existing green CTA component and remove its import
- add a new CTA to the service plans section offering document download

## Testing
- `pnpm exec next lint` *(fails: Command "next" not found)*
- `pnpm exec tsc --noEmit` *(fails to compile)*